### PR TITLE
Check for failed test message first

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -190,7 +190,9 @@ module.exports = function constructCore(TestRail, configs, process, console) {
                   // Otherwise, there was a failure. 5 means failure. Add fail message.
                   else {
                     caseResult.status_id = 5;
-                    caseResult.comment = HtmlEntities.decode(testcase.children[0].attributes.message);
+                    if (testcase.children[0].attributes.message){
+                      caseResult.comment = HtmlEntities.decode(testcase.children[0].attributes.message);
+                    }
                   }
 
                   // Only append tests we've mapped to a TestRail case.


### PR DESCRIPTION
Casper tests are not being reported to Test Rail when there's a failure in a test run. Adding a check for message property when encountering a failed test case to avoid TypeErrors. 

This closes #8 .